### PR TITLE
Pass Loader=yaml.SafeLoader when calling yaml.load()

### DIFF
--- a/spotinst_sdk/__init__.py
+++ b/spotinst_sdk/__init__.py
@@ -91,18 +91,18 @@ class SpotinstClient:
     # region Event Subscription
     def create_event_subscription(self, subscription):
         """
-        Create an event subscription 
-        
+        Create an event subscription
+
         # Arguments
         subscription (Subscription): Subscription Object
-        
+
         # Returns
-        (Object): Subscription API response 
-        """ 
+        (Object): Subscription API response
+        """
         subscription = spotinst_event_subscription.SubscriptionRequest(subscription)
 
         excluded_group_dict = self.exclude_missing(json.loads(subscription.toJSON()))
-        
+
         formatted_group_dict = self.convert_json(
             excluded_group_dict, self.underscore_to_camel)
 
@@ -122,24 +122,24 @@ class SpotinstClient:
 
     def update_event_subscription(self, subscription_id, subscription):
         """
-        Update an exsisting event subscription 
-        
+        Update an exsisting event subscription
+
         # Arguments
         subscription_id (String): Subscription id
         subscription (Subscription): Subscription Object
-        
+
         # Returns
-        (Object): Subscription API response 
-        """ 
+        (Object): Subscription API response
+        """
         subscription = spotinst_event_subscription.SubscriptionRequest(subscription)
 
         excluded_group_dict = self.exclude_missing(json.loads(subscription.toJSON()))
-        
+
         formatted_group_dict = self.convert_json(
             excluded_group_dict, self.underscore_to_camel)
 
         body_json = json.dumps(formatted_group_dict)
-        
+
         group_response = self.send_put(
             body=body_json,
             url=self.__base_event_subscription_url +
@@ -156,10 +156,10 @@ class SpotinstClient:
     def get_all_event_subscription(self):
         """
         Get all Subscription in account
-        
+
         # Returns
-        (Object): Subscription API response 
-        """ 
+        (Object): Subscription API response
+        """
         response = self.send_get(
             url=self.__base_event_subscription_url,
             entity_name="subscription"
@@ -175,13 +175,13 @@ class SpotinstClient:
     def get_event_subscription(self, subscription_id):
         """
         Get an exsisting event subscription json
-        
+
         # Arguments
         subscription_id (String): Subscription id
-        
+
         # Returns
-        (Object): Subscription API response 
-        """ 
+        (Object): Subscription API response
+        """
         response = self.send_get(
             url=self.__base_event_subscription_url +
             "/" + subscription_id,
@@ -193,25 +193,25 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal        
-    
+        return retVal
+
     def delete_event_subscription(self, subscription_id):
         """
         Delete an event subscription
-        
+
         # Arguments
         subscription_id (String): Subscription id
-        
+
         # Returns
-        (Object): subscription response 
-        """ 
+        (Object): subscription response
+        """
         response = self.send_delete(
             url=self.__base_event_subscription_url +
             "/" + subscription_id,
             entity_name="subscription"
         )
 
-        return response  
+        return response
     # end region
 
 
@@ -222,11 +222,11 @@ class SpotinstClient:
     # region MLB
     def get_all_mlb_runtime(self):
         """
-        Get all MLB runtime 
-        
+        Get all MLB runtime
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_get(
             url=self.__base_lb_url +
             "/runtime",
@@ -238,18 +238,18 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"]
 
-        return retVal     
+        return retVal
 
     def get_mlb_runtime(self, runtime_id):
         """
         Get MLB runtime
-        
+
         # Arguments
         runtime_id (String): Runtime id name
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_get(
             url=self.__base_lb_url +
             "/runtime/" + runtime_id,
@@ -261,18 +261,18 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal     
+        return retVal
 
     def deregister_mlb_runtime(self, runtime_id):
         """
         Deregister MLB runtime
-        
+
         # Arguments
         runtime_id (String): Runtime id name
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_put(
             url=self.__base_lb_url +
             "/runtime/" + runtime_id +
@@ -285,36 +285,36 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["status"]
 
-        return retVal   
+        return retVal
 
     def delete_mlb_runtime(self, runtime_id):
         """
         Delete MLB runtime
-        
+
         # Arguments
         runtime_id (String): Runtime id name
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_delete(
             url=self.__base_lb_url +
             "/runtime/" + runtime_id,
             entity_name="mlb runtime"
         )
 
-        return response 
+        return response
 
     def create_mlb_deployment(self, deployment_name):
         """
         Create MLB deployment
-        
+
         # Arguments
         deployment_name (String): Deployment name
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_post(
             url=self.__base_lb_url +
             "/deployment",
@@ -327,19 +327,19 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal 
+        return retVal
 
     def update_mlb_deployment(self, deployment_id, deployment_name):
         """
         Update MLB deployment
-        
+
         # Arguments
         deployment_name (String): Deployment name
         deployment_id (String): Deployment Id
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_put(
             url=self.__base_lb_url +
             "/deployment/" + deployment_id,
@@ -351,61 +351,61 @@ class SpotinstClient:
             response, self.camel_to_underscore)
         retVal = formatted_response["response"]["status"]
 
-        return retVal 
+        return retVal
 
     def get_mlb_deployment(self, deployment_id):
         """
         Get MLB deployment
-        
+
         # Arguments
         deployment_id (String): Deployment Id
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_get(
             url=self.__base_lb_url +
             "/deployment/"+deployment_id,
             entity_name="mlb deployment"
         )
-        
+
         formatted_response = self.convert_json(
             response, self.camel_to_underscore)
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal 
+        return retVal
 
     def get_all_mlb_deployment(self):
         """
         Get All MLB deployment
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_get(
             url=self.__base_lb_url +
             "/deployment",
             entity_name="mlb deployment"
         )
-        
+
         formatted_response = self.convert_json(
             response, self.camel_to_underscore)
 
         retVal = formatted_response["response"]["items"]
 
-        return retVal 
+        return retVal
 
     def delete_mlb_deployment(self, deployment_id):
         """
         Delete MLB deployment
-        
+
         # Arguments
         deployment_id (String): Deployment Id
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_delete(
             url=self.__base_lb_url +
             "/deployment/"+deployment_id,
@@ -417,13 +417,13 @@ class SpotinstClient:
     def create_mlb_balancer(self, balancer):
         """
         Create MLB balancer
-        
+
         # Arguments
         balancer (Balancer): Balancer Object
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         balancer = spotinst_mlb.BalancerRequest(balancer)
 
         excluded_group_dict = self.exclude_missing(json.loads(balancer.toJSON()))
@@ -447,19 +447,19 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal        
+        return retVal
 
     def update_mlb_balancer(self, balancer_id, balancer):
         """
         Create MLB balancer
-        
+
         # Arguments
         balancer_id (String): Balancer Id
         balancer (Balancer): Balancer Object
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         balancer = spotinst_mlb.BalancerRequest(balancer)
 
         excluded_group_dict = self.exclude_missing(json.loads(balancer.toJSON()))
@@ -477,28 +477,28 @@ class SpotinstClient:
             body=body_json,
             entity_name="mlb balancer"
         )
-        
+
         formatted_response = self.convert_json(
             response, self.camel_to_underscore)
 
         retVal = formatted_response["response"]["status"]
 
-        return retVal 
+        return retVal
 
     def get_mlb_balancer(self, balancer_id):
         """
         Get MLB balancer
-        
+
         # Arguments
         balancer_id (String): Balancer Id
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_get(
             url=self.__base_lb_url +
             "/balancer/" + balancer_id,
-            entity_name="mlb balancer" 
+            entity_name="mlb balancer"
         )
 
         formatted_response = self.convert_json(
@@ -506,19 +506,19 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal        
+        return retVal
 
     def get_all_mlb_balancer(self):
         """
         Get All MLB balancer
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_get(
             url=self.__base_lb_url +
             "/balancer/",
-            entity_name="mlb balancer" 
+            entity_name="mlb balancer"
         )
 
         formatted_response = self.convert_json(
@@ -526,35 +526,35 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"]
 
-        return retVal   
+        return retVal
 
     def delete_mlb_balancer(self, balancer_id):
         """
         Delete MLB balancer
-        
+
         # Arguments
         balancer_id (String): Balancer Id
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_delete(
             url=self.__base_lb_url +
             "/balancer/" + balancer_id,
-            entity_name="mlb balancer" 
+            entity_name="mlb balancer"
         )
 
-        return response   
+        return response
 
     def create_mlb_target_set(self, target_set):
         """
         Create MLB target set
-        
+
         # Arguments
         target_set (TargetSet): TargetSet Object
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         target_set = spotinst_mlb.TargetSetRequest(target_set)
 
@@ -573,24 +573,24 @@ class SpotinstClient:
             body=body_json,
             entity_name="mlb target set"
         )
-        
+
         formatted_response = self.convert_json(
             response, self.camel_to_underscore)
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal 
+        return retVal
 
     def update_mlb_target_set(self, target_set_id, target_set):
         """
         Update MLB target set
-        
+
         # Arguments
         target_set_id (String): Target Set Id
         target_set (TargetSet): TargetSet Object
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         target_set = spotinst_mlb.TargetSetRequest(target_set)
 
@@ -609,23 +609,23 @@ class SpotinstClient:
             body=body_json,
             entity_name="mlb target set"
         )
-        
+
         formatted_response = self.convert_json(
             response, self.camel_to_underscore)
 
         retVal = formatted_response["response"]["status"]
 
-        return retVal 
+        return retVal
 
     def get_mlb_target_set(self, target_set_id):
         """
         Gat an MLB target set
-        
+
         # Arguments
         target_set_id (String): Target Set Id
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_get(
             url=self.__base_lb_url +
@@ -638,14 +638,14 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal 
+        return retVal
 
     def get_all_mlb_target_set(self):
         """
         Get all MLB target sets
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_get(
             url=self.__base_lb_url +
@@ -658,17 +658,17 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"]
 
-        return retVal 
+        return retVal
 
     def delete_mlb_target_set(self, target_set_id):
         """
         Delete an MLB target set
-        
+
         # Arguments
         target_set_id (String): Target Set Id
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_delete(
             url=self.__base_lb_url +
@@ -676,18 +676,18 @@ class SpotinstClient:
             entity_name="mlb target set"
         )
 
-        return response 
+        return response
 
     def register_mlb_targets(self, target_set_id, targets):
         """
         Register MLB targets
-        
+
         # Arguments
         target_set_id (String): Target Set Id
         Targets (List[Target]): List of Target Objects
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         targets = spotinst_mlb.TargetsRequest(targets)
 
@@ -713,18 +713,18 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"]
 
-        return retVal 
+        return retVal
 
     def deregister_mlb_targets(self, target_set_id, targets):
         """
         Deregister MLB targets
-        
+
         # Arguments
         target_set_id (String): Target Set Id
         Targets (List[Target]): List of Target Objects
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         targets = spotinst_mlb.TargetsRequest(targets)
 
@@ -750,17 +750,17 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["status"]
 
-        return retVal 
+        return retVal
 
     def create_mlb_target(self, target):
         """
         Create MLB target
-        
+
         # Arguments
         target (Target): Target Object
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         target = spotinst_mlb.TargetRequest(target)
 
@@ -785,18 +785,18 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal 
+        return retVal
 
     def update_mlb_target(self, target_id, target):
         """
         Update MLB target
-        
+
         # Arguments
         target_id (String): Target Id
         target (Target): Target Object
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         target = spotinst_mlb.TargetRequest(target)
 
@@ -821,22 +821,22 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["status"]
 
-        return retVal 
+        return retVal
 
     def get_mlb_target(self, target_id):
         """
         Get MLB target
-        
+
         # Arguments
         target_id (String): Target Id
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_get(
             url=self.__base_lb_url +
             "/target/"+target_id,
-            entity_name="mlb target"            
+            entity_name="mlb target"
         )
 
         formatted_response = self.convert_json(
@@ -844,19 +844,19 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal 
+        return retVal
 
     def get_all_mlb_target(self):
         """
         Get all MLB target
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_get(
             url=self.__base_lb_url +
             "/target",
-            entity_name="mlb target"            
+            entity_name="mlb target"
         )
 
         formatted_response = self.convert_json(
@@ -864,35 +864,35 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"]
 
-        return retVal 
+        return retVal
 
     def delete_mlb_target(self, target_id):
         """
         Delete MLB target
-        
+
         # Arguments
         target_id (String): Target Id
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_delete(
             url=self.__base_lb_url +
             "/target/"+target_id,
-            entity_name="mlb target"            
+            entity_name="mlb target"
         )
 
-        return response 
+        return response
 
     def create_mlb_listener(self, listener):
         """
         Create MLB listener
-        
+
         # Arguments
         listener (Listener): Listener Object
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         listener = spotinst_mlb.ListenerRequest(listener)
 
@@ -917,18 +917,18 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal 
+        return retVal
 
     def update_mlb_listener(self, listener_id, listener):
         """
         Update MLB listener
-        
+
         # Arguments
         listener_id (String): Listener ID
         listener (Listener): Listener Object
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         listener = spotinst_mlb.ListenerRequest(listener)
 
@@ -953,17 +953,17 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["status"]
 
-        return retVal 
+        return retVal
 
     def get_mlb_listener(self, listener_id):
         """
         Get MLB listener
-        
+
         # Arguments
         listener_id (String): Listener ID
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_get(
             url=self.__base_lb_url +
@@ -976,14 +976,14 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal 
+        return retVal
 
     def get_all_mlb_listener(self):
         """
         Get all MLB listeners
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_get(
             url=self.__base_lb_url +
@@ -996,17 +996,17 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"]
 
-        return retVal 
+        return retVal
 
     def delete_mlb_listener(self, listener_id):
         """
         Delete MLB listener
-        
+
         # Arguments
         listener_id (String): Listener ID
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_delete(
             url=self.__base_lb_url +
@@ -1014,17 +1014,17 @@ class SpotinstClient:
             entity_name="mlb listener"
         )
 
-        return response 
+        return response
 
     def create_mlb_routing_rule(self, routing_rule):
         """
         Create MLB routing rule
-        
+
         # Arguments
         routing_rule (RoutingRule): RoutingRule Object
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         routing_rule = spotinst_mlb.RoutingRuleRequest(routing_rule)
 
@@ -1049,18 +1049,18 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal 
+        return retVal
 
     def update_mlb_routing_rule(self, routing_rule_id, routing_rule):
         """
         Update MLB routing rule
-        
+
         # Arguments
         routing_rule_id (String): Routing Rule Id
         routing_rule (RoutingRule): RoutingRule Object
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         routing_rule = spotinst_mlb.RoutingRuleRequest(routing_rule)
 
@@ -1085,17 +1085,17 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["status"]
 
-        return retVal 
+        return retVal
 
     def get_mlb_routing_rule(self, routing_rule_id):
         """
         Get MLB routing rule
-        
+
         # Arguments
         routing_rule_id (String): Routing Rule Id
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_get(
             url=self.__base_lb_url +
@@ -1108,14 +1108,14 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal 
+        return retVal
 
     def get_all_mlb_routing_rule(self):
         """
         Get all MLB routing rule
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_get(
             url=self.__base_lb_url +
@@ -1128,17 +1128,17 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"]
 
-        return retVal 
+        return retVal
 
     def delete_mlb_routing_rule(self, routing_rule_id):
         """
         Delete MLB routing rule
-        
+
         # Arguments
         routing_rule_id (String): Routing Rule Id
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_delete(
             url=self.__base_lb_url +
@@ -1146,17 +1146,17 @@ class SpotinstClient:
             entity_name="mlb routing rule"
         )
 
-        return response 
+        return response
 
     def create_mlb_middleware(self, middleware):
         """
         Create MLB middleware
-        
+
         # Arguments
         middleware (Middleware): Middleware Object
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         middleware = spotinst_mlb.MiddlewareRequest(middleware)
 
@@ -1181,18 +1181,18 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal 
+        return retVal
 
     def update_mlb_middleware(self, middleware_id, middleware):
         """
         Update MLB middleware
-        
+
         # Arguments
         middleware_id (String): Middleware ID
         middleware (Middleware): Middleware Object
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         middleware = spotinst_mlb.MiddlewareRequest(middleware)
 
@@ -1217,17 +1217,17 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["status"]
 
-        return retVal 
+        return retVal
 
     def get_mlb_middleware(self, middleware_id):
         """
         Get MLB middleware
-        
+
         # Arguments
         middleware_id (String): Middleware ID
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_get(
             url=self.__base_lb_url +
@@ -1240,14 +1240,14 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal 
+        return retVal
 
     def get_all_mlb_middleware(self):
         """
         Get all MLB middleware
-                
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_get(
             url=self.__base_lb_url +
@@ -1260,17 +1260,17 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"]
 
-        return retVal 
+        return retVal
 
     def delete_mlb_middleware(self, middleware_id):
         """
         Delete MLB middleware
-        
+
         # Arguments
         middleware_id (String): Middleware ID
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_delete(
             url=self.__base_lb_url +
@@ -1278,7 +1278,7 @@ class SpotinstClient:
             entity_name="mlb middleware"
         )
 
-        return response 
+        return response
     # endregion
 
 
@@ -1286,16 +1286,16 @@ class SpotinstClient:
     # region Organization and Account
     def create_organization(self, org_name):
         """
-        Create an organization 
-        
+        Create an organization
+
         # Arguments
         org_name (String): Orgnanization name
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_post(
-            url= self.__base_setup_url + 
+            url= self.__base_setup_url +
             "/organization",
             body=json.dumps(dict(organization=dict(name=org_name))),
             entity_name="organization"
@@ -1310,16 +1310,16 @@ class SpotinstClient:
 
     def delete_organization(self, org_id):
         """
-        delete organization 
-        
+        delete organization
+
         # Arguments
         org_id (String): Organization Id
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_delete(
-            url= self.__base_setup_url + 
+            url= self.__base_setup_url +
             "/organization/" + str(org_id),
             entity_name="organization"
         )
@@ -1328,15 +1328,15 @@ class SpotinstClient:
 
     def set_cloud_credentials(self, iam_role, external_id):
         """
-        set cloud credentials 
-        
+        set cloud credentials
+
         # Arguments
         iam_role (String): IAM Role
         external_id (String): External ID
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_post(
             url= self.__base_setup_url +
             "/credentials/aws",
@@ -1353,14 +1353,14 @@ class SpotinstClient:
 
     def create_account(self, account_name):
         """
-        create an account 
-        
+        create an account
+
         # Arguments
         account_name (String): Account Name
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_post(
             url= self.__base_setup_url +
             "/account",
@@ -1378,10 +1378,10 @@ class SpotinstClient:
     def get_accounts(self):
         """
         get accounts in organization
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_get(
             url= self.__base_setup_url +
             "/account",
@@ -1398,13 +1398,13 @@ class SpotinstClient:
     def delete_account(self, account_name):
         """
         delete account
-        
+
         # Arguments
         account_name (String): Account Name
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_delete(
             url= self.__base_setup_url +
             "/account/" + account_name,
@@ -1416,7 +1416,7 @@ class SpotinstClient:
     def create_user(self, first_name, last_name, email, password, role):
         """
         Create user
-        
+
         # Arguments
         first_name (String): Users first name
         last_name (String): User last name
@@ -1424,10 +1424,10 @@ class SpotinstClient:
         password (String): User email
         role (String): User role
 
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_post(
             url= self.__base_setup_url +
             "/user",
@@ -1445,19 +1445,19 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal       
+        return retVal
 
     def add_exsisting_user(self, user_email, role):
         """
         Add exsisting user
-        
+
         # Arguments
         user_email (String): User email
         role (String): User role
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_post(
             url= self.__base_setup_url +
             "/account/" + self.account_id +
@@ -1471,19 +1471,19 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["status"]
 
-        return retVal 
+        return retVal
 
     def update_user_role(self, user_email, role):
         """
         Update exsisting user
-        
+
         # Arguments
         user_email (String): User email
         role (String): User role
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_put(
             url= self.__base_setup_url +
             "/account/" + self.account_id +
@@ -1497,18 +1497,18 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["status"]
 
-        return retVal 
+        return retVal
 
     def detach_user(self, user_email):
         """
         Delete exsisting user
-        
+
         # Arguments
         user_email (String): User email
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         response = self.send_delete_with_body(
             url= self.__base_setup_url +
             "/account/" + self.account_id +
@@ -1517,18 +1517,18 @@ class SpotinstClient:
             entity_name="user"
         )
 
-        return response 
+        return response
 
     def get_user(self, user_email):
         """
         Get user
-        
+
         # Arguments
         user_email (String): User email
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         query_params= dict(userEmail=user_email)
         response = self.send_get(
             url= self.__base_setup_url + "/accountUserMapping",
@@ -1541,22 +1541,22 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"]
 
-        return retVal 
+        return retVal
 
     def assign_user_to_account(self, mappings):
         """
         Assign user to account
-        
+
         # Arguments
         mappings (List): List of UserMapping Objects
-        
+
         # Returns
-        (Object): Spotinst API response 
-        """ 
+        (Object): Spotinst API response
+        """
         mappings = spotinst_user_mapping.UserMappingRequest(mappings)
 
         excluded_group_dict = self.exclude_missing(json.loads(mappings.toJSON()))
-        
+
         formatted_group_dict = self.convert_json(
             excluded_group_dict, self.underscore_to_camel)
 
@@ -1573,7 +1573,7 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["status"]
 
-        return retVal 
+        return retVal
     # endregion
 
 
@@ -1581,23 +1581,23 @@ class SpotinstClient:
     # region EMR
     def create_emr(self, emr):
         """
-        Create an EMR 
-        
+        Create an EMR
+
         # Arguments
         emr (EMR): EMR Object
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         emr = spotinst_emr.EMRCreationRequest(emr)
 
         excluded_group_dict = self.exclude_missing(json.loads(emr.toJSON()))
-        
+
         formatted_group_dict = self.convert_json(
             excluded_group_dict, self.underscore_to_camel)
 
         body_json = json.dumps(formatted_group_dict)
-        
+
         group_response = self.send_post(
             body=body_json,
             url=self.__base_emr_url,
@@ -1612,24 +1612,24 @@ class SpotinstClient:
 
     def update_emr(self, emr_id, emr):
         """
-        Update an exsisting EMR 
-        
+        Update an exsisting EMR
+
         # Arguments
         emr_id (String): EMR id
         emr (EMR): EMR Object
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         emr = spotinst_emr.EMRCreationRequest(emr)
 
         excluded_group_dict = self.exclude_missing(json.loads(emr.toJSON()))
-        
+
         formatted_group_dict = self.convert_json(
             excluded_group_dict, self.underscore_to_camel)
 
         body_json = json.dumps(formatted_group_dict)
-        
+
         group_response = self.send_put(
             body=body_json,
             url=self.__base_emr_url +
@@ -1646,10 +1646,10 @@ class SpotinstClient:
     def get_all_emr(self):
         """
         Get all EMR in account
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         response = self.send_get(
             url=self.__base_emr_url,
             entity_name="emr"
@@ -1665,13 +1665,13 @@ class SpotinstClient:
     def get_emr(self, emr_id):
         """
         Get an exsisting EMR json
-        
+
         # Arguments
         emr_id (String): EMR id
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         response = self.send_get(
             url=self.__base_emr_url +
             "/" + emr_id,
@@ -1683,18 +1683,18 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal        
+        return retVal
 
     def get_emr_instances(self, emr_id):
         """
-        Get instances from EMR 
-        
+        Get instances from EMR
+
         # Arguments
         emr_id (String): EMR id
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         response = self.send_get(
             url=self.__base_emr_url +
             "/" + emr_id +
@@ -1707,18 +1707,18 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"]
 
-        return retVal  
+        return retVal
 
     def get_emr_cluster(self, emr_id):
         """
         Get cluster from EMR
-        
+
         # Arguments
         emr_id (String): EMR id
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         response = self.send_get(
             url=self.__base_emr_url +
             "/" + emr_id +
@@ -1736,15 +1736,15 @@ class SpotinstClient:
     def get_emr_cost(self, emr_id, from_date=None, to_date=None):
         """
         Get cost from EMR
-        
+
         # Arguments
         emr_id (String): EMR id
         from_date (String) (Optional): From Date
         to_date (String) (Optional): to date
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         query_params = dict(fromDate=from_date, toDate=to_date)
 
         response = self.send_get(
@@ -1765,32 +1765,32 @@ class SpotinstClient:
     def delete_emr(self, emr_id):
         """
         Delete an EMR
-        
+
         # Arguments
         emr_id (String): EMR id
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         response = self.send_delete(
             url=self.__base_emr_url +
             "/" + emr_id,
             entity_name="emr"
         )
 
-        return response  
+        return response
 
     def scale_up_emr(self, emr_id, adjustment):
         """
         Scale up an EMR
-        
+
         # Arguments
         emr_id (String): EMR id
         adjustment (Int): Ammount to scale
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         query_params = dict(adjustment=adjustment)
 
         response = self.send_put(
@@ -1811,14 +1811,14 @@ class SpotinstClient:
     def scale_down_emr(self, emr_id, adjustment):
         """
         Scale down an EMR
-        
+
         # Arguments
         emr_id (String): EMR id
         adjustment (Int): Ammount to scale
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         query_params = dict(adjustment=adjustment)
 
         response = self.send_put(
@@ -1842,18 +1842,18 @@ class SpotinstClient:
     # region Ocean
     def create_ocean_cluster(self, ocean):
         """
-        Create an Ocean Cluster 
-        
+        Create an Ocean Cluster
+
         # Arguments
         ocean (Ocean): Ocean Object
-        
+
         # Returns
-        (Object): Ocean API response 
-        """ 
+        (Object): Ocean API response
+        """
         ocean = spotinst_ocean.OceanRequest(ocean)
 
         excluded_group_dict = self.exclude_missing(json.loads(ocean.toJSON()))
-        
+
         formatted_group_dict = self.convert_json(
             excluded_group_dict, self.underscore_to_camel)
 
@@ -1873,24 +1873,24 @@ class SpotinstClient:
 
     def update_ocean_cluster(self, ocean_id, ocean):
         """
-        Update an exsisting Ocean Cluster 
-        
+        Update an exsisting Ocean Cluster
+
         # Arguments
         ocean_id (String): Ocean id
         ocean (Ocean): Ocean Object
-        
+
         # Returns
-        (Object): Ocean API response 
-        """ 
+        (Object): Ocean API response
+        """
         ocean = spotinst_ocean.OceanRequest(ocean)
 
         excluded_group_dict = self.exclude_missing(json.loads(ocean.toJSON()))
-        
+
         formatted_group_dict = self.convert_json(
             excluded_group_dict, self.underscore_to_camel)
 
         body_json = json.dumps(formatted_group_dict)
-        
+
         group_response = self.send_put(
             body=body_json,
             url=self.__base_ocean_url +
@@ -1907,10 +1907,10 @@ class SpotinstClient:
     def get_all_ocean_cluster(self):
         """
         Get all Ocean in account
-        
+
         # Returns
-        (Object): Ocean API response 
-        """ 
+        (Object): Ocean API response
+        """
         response = self.send_get(
             url=self.__base_ocean_url,
             entity_name="ocean"
@@ -1926,13 +1926,13 @@ class SpotinstClient:
     def get_ocean_cluster(self, ocean_id):
         """
         Get an exsisting Ocean Cluster json
-        
+
         # Arguments
         ocean_id (String): Ocean id
-        
+
         # Returns
-        (Object): Ocean API response 
-        """ 
+        (Object): Ocean API response
+        """
         response = self.send_get(
             url=self.__base_ocean_url +
             "/" + ocean_id,
@@ -1944,25 +1944,25 @@ class SpotinstClient:
 
         retVal = formatted_response["response"]["items"][0]
 
-        return retVal        
-    
+        return retVal
+
     def delete_ocean_cluster(self, ocean_id):
         """
         Delete an Ocean Cluster
-        
+
         # Arguments
         ocean_id (String): Ocean id
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         response = self.send_delete(
             url=self.__base_ocean_url +
             "/" + ocean_id,
             entity_name="ocean"
         )
 
-        return response  
+        return response
     # endregion
 
 
@@ -1970,18 +1970,18 @@ class SpotinstClient:
 
     # region Kubernetes
 
-    def get_kubernetes_cluster_cost(self, custer_id, from_date, to_date):   
+    def get_kubernetes_cluster_cost(self, custer_id, from_date, to_date):
         """
-        Get kubernetes cluster cost 
-        
+        Get kubernetes cluster cost
+
         # Arguments
         custer_id (String): Kubernetes cluster id
         from_date (String): From date
         to_date (String): to date
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """      
+        (Object): Elastigroup API response
+        """
         geturl = self.__base_kube_url + "/" + custer_id + "/costs"
         query_params = self.build_query_params_with_input({"toDate":to_date, "fromDate":from_date})
 
@@ -2002,13 +2002,13 @@ class SpotinstClient:
     def create_elastigroup(self, group):
         """
         Create an elastigroup
-        
+
         # Arguments
         group (Elastigroup): Elastigroup Object
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """    
+        (Object): Elastigroup API response
+        """
         group = aws_elastigroup.ElastigroupCreationRequest(group)
 
         excluded_group_dict = self.exclude_missing(json.loads(group.toJSON()))
@@ -2035,14 +2035,14 @@ class SpotinstClient:
     def scale_elastigroup_up(self, group_id, adjustment):
         """
         Scale up an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         adjustment (int): Ammount to scale group
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """   
+        (Object): Elastigroup API response
+        """
         query_params = dict({"adjustment": adjustment})
         content = self.send_put_with_params(
             url=self.__base_elastigroup_url +
@@ -2060,13 +2060,13 @@ class SpotinstClient:
     def scale_elastigroup_down(self, group_id, adjustment):
         """
         Scale down an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         adjustment (int): Ammount to scale group
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         query_params = dict({"adjustment": adjustment})
         content = self.send_put_with_params(
@@ -2085,13 +2085,13 @@ class SpotinstClient:
     def update_elastigroup(self, group_update, group_id, auto_apply_tags=None):
         """
         Update an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         group_update (Elastigroup): Elastigroup Object
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         group = aws_elastigroup.ElastigroupUpdateRequest(group_update)
 
@@ -2106,9 +2106,9 @@ class SpotinstClient:
         self.print_output(body_json)
 
         group_response = self.send_put_with_params(
-            body=body_json, 
-            url=self.__base_elastigroup_url + "/" + group_id, 
-            entity_name='elastigroup', 
+            body=body_json,
+            url=self.__base_elastigroup_url + "/" + group_id,
+            entity_name='elastigroup',
             user_query_params=dict(autoApplyTags=auto_apply_tags)
         )
 
@@ -2122,12 +2122,12 @@ class SpotinstClient:
     def delete_elastigroup(self, group_id):
         """
         Delete an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         delurl = self.__base_elastigroup_url + "/" + group_id
         response = self.send_delete(url=delurl, entity_name='elastigroup')
@@ -2136,13 +2136,13 @@ class SpotinstClient:
     def delete_elastigroup_with_deallocation(self, group_id, stateful_deallocation):
         """
         Delete a stateful elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         stateful_deallocation (Deallocation): Deallocation Object
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         delurl = self.__base_elastigroup_url + "/" + group_id
 
@@ -2163,7 +2163,7 @@ class SpotinstClient:
     def get_elastilog(self, group_id, from_date, to_date, severity=None, resource_id=None, limit=None):
         """
         Get an elastilog for a specific elastigroup
-        
+
         # Arguments
         group_id(String): Elastigroup ID
         to_date (String): to date
@@ -2171,12 +2171,12 @@ class SpotinstClient:
         severity(String) (Optional): Log level severity
         resource_id(String) (Optional): Filter log extracted entires related to a specific resource id
         limit(String) (Optional): Maximum number of lines to extract in a response
-       
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         geturl = self.__base_elastigroup_url + "/" + group_id + "/logs"
-        query_params=dict(toDate=to_date, fromDate=from_date, severity=severity, 
+        query_params=dict(toDate=to_date, fromDate=from_date, severity=severity,
             resource_id=resource_id, limit=limit)
 
         result = self.send_get(url=geturl, entity_name='elastilog', query_params=query_params)
@@ -2189,12 +2189,12 @@ class SpotinstClient:
     def get_elastigroup(self, group_id):
         """
         Get an elastigroup
-        
+
         # Arguments
         group_id(String): Elastigroup ID
-       
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         geturl = self.__base_elastigroup_url + "/" + group_id
         result = self.send_get(url=geturl, entity_name='elastigroup')
@@ -2207,9 +2207,9 @@ class SpotinstClient:
     def get_elastigroups(self):
         """
         Get all elastigroup
-        
+
         # Returns
-        (List): List of Elastigroup API response 
+        (List): List of Elastigroup API response
         """
         content = self.send_get(
             url=self.__base_elastigroup_url,
@@ -2221,12 +2221,12 @@ class SpotinstClient:
     def get_elastigroup_active_instances(self, group_id):
         """
         Get active instances of an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         content = self.send_get(
             url=self.__base_elastigroup_url +
@@ -2241,13 +2241,13 @@ class SpotinstClient:
     def get_elastigroup_activity(self, group_id, start_date):
         """
         Get elastigroup activity
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         start_date (String): Date when to start checking
-        
+
         # Returns
-        (Object) : Elastigroup API response 
+        (Object) : Elastigroup API response
         """
         query_params = self.build_query_params_with_input({"fromDate":start_date})
 
@@ -2266,13 +2266,13 @@ class SpotinstClient:
     def roll_group(self, group_id, group_roll):
         """
         Roll an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         group_roll (ElastigroupRoll): GroupRoll Object
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         group_roll_request = aws_elastigroup.ElastigroupRollRequest(
             group_roll=group_roll)
@@ -2304,12 +2304,12 @@ class SpotinstClient:
     def get_all_group_deployment(self, group_id):
         """
         get all group deployment from an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         content = self.send_get(
             url=self.__base_elastigroup_url +
@@ -2325,13 +2325,13 @@ class SpotinstClient:
     def get_deployment_status(self, group_id, roll_id):
         """
         get all a deployment status from an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         roll_id (String): Deployment ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         content = self.send_get(
             url=self.__base_elastigroup_url +
@@ -2349,13 +2349,13 @@ class SpotinstClient:
     def stop_deployment(self, group_id, roll_id):
         """
         stop a deployment from an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         roll_id (String): Deployment ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         content = self.send_put(
             url=self.__base_elastigroup_url +
@@ -2374,14 +2374,14 @@ class SpotinstClient:
     def create_deployment_action(self, group_id, roll_id, deployment_action):
         """
         create a deployment from an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         roll_id (String): Deployment ID
         deployment_action (Deployment): Deployment Object
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         deployment_action_request = spotinst_deployment_action.DeploymentActionRequest(deployment_action)
 
@@ -2412,12 +2412,12 @@ class SpotinstClient:
     def get_instance_type_by_region(self, region):
         """
         Get instance type by region
-        
+
         # Arguments
         region (String): AWS region
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         query_params = dict(region=region)
         response = self.send_get(
@@ -2434,14 +2434,14 @@ class SpotinstClient:
 
     def lock_instance(self, instance_id, lock_time=None):
         """
-        Lock instance 
-        
+        Lock instance
+
         # Arguments
         instance_id (String): Instance ID
         lock_time (int) (Optinal): Time to lock instance
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         query_params= dict(ttlInMinutes=lock_time)
 
@@ -2461,13 +2461,13 @@ class SpotinstClient:
 
     def unlock_instance(self, instance_id):
         """
-        Unlock instance 
-        
+        Unlock instance
+
         # Arguments
         instance_id (String): Instance ID
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_post(
             url=self.__base_aws_url +
@@ -2476,7 +2476,7 @@ class SpotinstClient:
             "/unlock",
             entity_name="instance"
         )
-        
+
         formatted_response = self.convert_json(
             response, self. camel_to_underscore)
 
@@ -2484,17 +2484,17 @@ class SpotinstClient:
 
     def enter_instance_standby(self, instance_id):
         """
-        Enter standby for instance 
-        
+        Enter standby for instance
+
         # Arguments
         instance_id (String): Instance ID
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_post(
-            url=self.__base_aws_url + 
-            "/instance/" + 
+            url=self.__base_aws_url +
+            "/instance/" +
             instance_id +
             "/standby/enter",
             entity_name="instance"
@@ -2507,17 +2507,17 @@ class SpotinstClient:
 
     def exit_instance_standby(self, instance_id):
         """
-        Exit standby for instance 
-        
+        Exit standby for instance
+
         # Arguments
         instance_id (String): Instance ID
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_post(
-            url=self.__base_aws_url + 
-            "/instance/" + 
+            url=self.__base_aws_url +
+            "/instance/" +
             instance_id +
             "/standby/exit",
             entity_name="instance"
@@ -2531,15 +2531,15 @@ class SpotinstClient:
     def get_instance_status(self, instance_id):
         """
         Get instance status
-        
+
         # Arguments
         instance_id (String): Instance ID
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         response = self.send_get(
-            url=self.__base_aws_url + 
+            url=self.__base_aws_url +
             "/instance/" +
             instance_id,
             entity_name="instance"
@@ -2553,16 +2553,16 @@ class SpotinstClient:
     def get_instance_healthiness(self, group_id):
         """
         get all instances a healthyness from an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         response = self.send_get(
             url=self.__base_elastigroup_url +
-             "/" + group_id + 
+             "/" + group_id +
             "/instanceHealthiness",
             entity_name="instance"
         )
@@ -2575,18 +2575,18 @@ class SpotinstClient:
     def create_instance_signal(self, instance_id, signal):
         """
         create instance signal
-        
+
         # Arguments
         instance_id (String): instance ID
         signal (String): Signal
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         body = json.dumps(dict(instanceId=instance_id, signal=signal))
 
         response = self.send_post(
-            url= self.__base_aws_url + 
+            url= self.__base_aws_url +
             "/instance/signal",
             body=body,
             entity_name="instance"
@@ -2595,18 +2595,18 @@ class SpotinstClient:
         formatted_response = self.convert_json(
             response, self. camel_to_underscore)
 
-        return formatted_response["response"]["status"]  
+        return formatted_response["response"]["status"]
 
     def get_cost_per_account(self, to_date=None, from_date=None):
         """
         get cost per account
-        
+
         # Arguments
         to_date (String) (Optional): to date
         from_date (String) (Optional): to date
-        
+
         # Returns
-        (Object): Spotinst API response 
+        (Object): Spotinst API response
         """
         query_params=dict(toDate=to_date, fromDate=from_date)
 
@@ -2619,19 +2619,19 @@ class SpotinstClient:
         formatted_response = self.convert_json(
             response, self. camel_to_underscore)
 
-        return formatted_response["response"]["items"]  
+        return formatted_response["response"]["items"]
 
     def get_cost_per_elastigroup(self, group_id, to_date=None, from_date=None):
         """
         get cost per elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         to_date (String) (Optional): Start Date
         from_date (String) (Optional): End Date
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         query_params=dict(toDate=to_date, fromDate=from_date)
 
@@ -2646,19 +2646,19 @@ class SpotinstClient:
         formatted_response = self.convert_json(
             response, self. camel_to_underscore)
 
-        return formatted_response["response"]["items"]   
+        return formatted_response["response"]["items"]
 
     def get_group_detailed_cost(self, group_id, to_date=None, from_date=None):
         """
         get detailed cost per elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         to_date (String) (Optional): Start Date
         from_date (String) (Optional): End Date
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         query_params=dict(toDate=to_date, fromDate=from_date)
 
@@ -2673,14 +2673,14 @@ class SpotinstClient:
         formatted_response = self.convert_json(
             response, self. camel_to_underscore)
 
-        return formatted_response["response"]["items"] 
+        return formatted_response["response"]["items"]
 
     def get_potential_savings(self):
         """
-        get potential saving 
-                
+        get potential saving
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         response = self.send_get(
             url="https://api.spotinst.io/aws/potentialSavings",
@@ -2690,23 +2690,23 @@ class SpotinstClient:
         formatted_response = self.convert_json(
             response, self. camel_to_underscore)
 
-        return formatted_response["response"]["items"] 
+        return formatted_response["response"]["items"]
 
     def get_instance_potential_savings(self, instance_ids, region):
         """
-        get potential saving 
-        
+        get potential saving
+
         # Arguments
         instance_ids (List): List of instance id strings
         region (String): region
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         instance_str = ""
 
         for instance in instance_ids:
-            instance_str += instance + "," 
-        
+            instance_str += instance + ","
+
         query_params = dict(region=region, instanceIds=instance_str)
 
         response = self.send_get(
@@ -2718,21 +2718,21 @@ class SpotinstClient:
         formatted_response = self.convert_json(
             response, self. camel_to_underscore)
 
-        return formatted_response["response"]["items"] 
+        return formatted_response["response"]["items"]
 
     def list_suspended_scaling_policies(self, group_id):
         """
         get suspended scaling policies for an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         response = self.send_get(
             url=self.__base_elastigroup_url +
-            "/" + group_id + 
+            "/" + group_id +
             "/scale/suspensions",
             entity_name="scaling policies"
         )
@@ -2740,24 +2740,24 @@ class SpotinstClient:
         formatted_response = self.convert_json(
             response, self. camel_to_underscore)
 
-        return formatted_response["response"]["items"]   
+        return formatted_response["response"]["items"]
 
     def suspend_scaling_policies(self, group_id, policy_name):
         """
         suspended scaling policies for an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         policy_name (String): Scaling policy name
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         query_params = dict(policyName=policy_name)
 
         response = self.send_post(
             url=self.__base_elastigroup_url +
-            "/" + group_id + 
+            "/" + group_id +
             "/scale/suspendPolicy",
             query_params=query_params,
             entity_name="scaling policies"
@@ -2771,19 +2771,19 @@ class SpotinstClient:
     def resume_suspended_scaling_policies(self, group_id, policy_name):
         """
         Resume scaling policies for an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         policy_name (String): Scaling policy name
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         query_params = dict(policyName=policy_name)
 
         response = self.send_post(
             url=self.__base_elastigroup_url +
-            "/" + group_id + 
+            "/" + group_id +
             "/scale/resumePolicy",
             query_params=query_params,
             entity_name="scaling policies"
@@ -2797,16 +2797,16 @@ class SpotinstClient:
     def list_suspended_process(self, group_id):
         """
         List suspended process for an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         response = self.send_get(
             url=self.__base_elastigroup_url +
-            "/" + group_id + 
+            "/" + group_id +
             "/suspension",
             entity_name="suspend process"
         )
@@ -2819,14 +2819,14 @@ class SpotinstClient:
     def suspend_process(self, group_id, processes, suspensions):
         """
         suspended process for an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         processes (List): list of processes
         suspensions (List): list of suspensions
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
 
         if suspensions is not None:
@@ -2839,10 +2839,10 @@ class SpotinstClient:
             item_to_send = dict(processes=processes)
 
         body = json.dumps(item_to_send)
-        
+
         response = self.send_post(
             url=self.__base_elastigroup_url +
-            "/" + group_id + 
+            "/" + group_id +
             "/suspension",
             body=body,
             entity_name="suspend process"
@@ -2856,19 +2856,19 @@ class SpotinstClient:
     def remove_suspended_process(self, group_id, processes):
         """
         remove suspended process for an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         processes (List): list of processes
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         body = json.dumps(dict(processes=processes))
 
         response = self.send_delete_with_body(
             url=self.__base_elastigroup_url +
-            "/" + group_id + 
+            "/" + group_id +
             "/suspension",
             body=body,
             entity_name="suspend process"
@@ -2882,13 +2882,13 @@ class SpotinstClient:
     def detach_elastigroup_instances(self, group_id, detach_configuration):
         """
         Detatch instances from an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         detatch_configuration (Detach): Detach Object
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         group_detach_request = aws_elastigroup.ElastigroupDetachInstancesRequest(
             detach_configuration=detach_configuration)
@@ -2919,12 +2919,12 @@ class SpotinstClient:
     def import_stateful_instance(self, stateful_instance):
         """
         Import stateful instance parametes
-        
+
         # Arguments
         stateful_instance (StatefulInstance): StatefulInstance Object
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         stateful_instance = spotinst_stateful.StatefulImportRequest(stateful_instance)
 
@@ -2934,7 +2934,7 @@ class SpotinstClient:
             excluded_group_dict, self.underscore_to_camel)
 
         body_json = json.dumps(formatted_group_dict)
-        
+
         group_response = self.send_post(
             body=body_json,
             url=self.__base_stateful_url,
@@ -2950,12 +2950,12 @@ class SpotinstClient:
     def get_stateful_import_status(self, stateful_migration_id):
         """
         Get stateful instance status
-        
+
         # Arguments
         stateful_migration_id (String): Stateful migration ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         content = self.send_get(
             url=self.__base_stateful_url +
@@ -2966,17 +2966,17 @@ class SpotinstClient:
         formatted_response = self.convert_json(
             content, self.camel_to_underscore)
 
-        return formatted_response["response"]["items"] 
+        return formatted_response["response"]["items"]
 
     def delete_stateful_import(self, stateful_migration_id):
         """
-        Delete stateful instance 
-        
+        Delete stateful instance
+
         # Arguments
         stateful_migration_id (String): Stateful migration ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         content = self.send_delete(
             url=self.__base_stateful_url +
@@ -2991,13 +2991,13 @@ class SpotinstClient:
     def deallocate_stateful_instance(self, group_id, stateful_instance_id):
         """
         Deallocate stateful instances from an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         stateful_instance_id (String): Stateful Instance ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         content = self.send_put(
             url=self.__base_elastigroup_url +
@@ -3015,13 +3015,13 @@ class SpotinstClient:
     def recycle_stateful_instance(self, group_id, stateful_instance_id):
         """
         Recycle stateful instances from an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         stateful_instance_id (String): Stateful Instance ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         content = self.send_put(
             url=self.__base_elastigroup_url +
@@ -3039,13 +3039,13 @@ class SpotinstClient:
     def get_stateful_instances(self, group_id):
         """
         Deallocate stateful instances from an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         stateful_instance_id (String): Stateful Instance ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         content = self.send_get(
             url=self.__base_elastigroup_url +
@@ -3056,18 +3056,18 @@ class SpotinstClient:
 
         formatted_response = self.convert_json(
             content, self.camel_to_underscore)
-        return formatted_response["response"]["items"]           
+        return formatted_response["response"]["items"]
 
     def resume_stateful_instance(self, group_id, stateful_instance_id):
         """
         Resume stateful instances from an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         stateful_instance_id (String): Stateful Instance ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         content = self.send_put(
             url=self.__base_elastigroup_url +
@@ -3085,13 +3085,13 @@ class SpotinstClient:
     def pause_stateful_instance(self, group_id, stateful_instance_id):
         """
         Pause stateful instances from an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         stateful_instance_id (String): Stateful Instance ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         content = self.send_put(
             url=self.__base_elastigroup_url +
@@ -3110,17 +3110,17 @@ class SpotinstClient:
     def beanstalk_maintenance_status(self, group_id):
         """
         Beanstalk maintenance status
-        
+
         # Arguments
         group_id (String): Elastigroup ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         status_response = self.send_get(
             url=self.__base_elastigroup_url+
             "/" +
-            str(group_id) + 
+            str(group_id) +
             "/beanstalk/maintenance/status",
             entity_name="beanstalk maintenance start")
 
@@ -3134,17 +3134,17 @@ class SpotinstClient:
     def beanstalk_maintenance_start(self, group_id):
         """
         Beanstalk maintenance start
-        
+
         # Arguments
         group_id (String): Elastigroup ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         start_response = self.send_put(
             url=self.__base_elastigroup_url+
             "/" +
-            str(group_id) + 
+            str(group_id) +
             "/beanstalk/maintenance/start",
             body={},
             entity_name="beanstalk maintenance start")
@@ -3156,20 +3156,20 @@ class SpotinstClient:
 
         return retVal
 
-    def beanstalk_maintenance_finish(self, group_id):   
+    def beanstalk_maintenance_finish(self, group_id):
         """
         Beanstalk maintenance finish
-        
+
         # Arguments
         group_id (String): Elastigroup ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         finish_response = self.send_put(
             url=self.__base_elastigroup_url+
             "/" +
-            str(group_id) + 
+            str(group_id) +
             "/beanstalk/maintenance/finish",
             body={},
             entity_name="beanstalk maintenance start")
@@ -3184,14 +3184,14 @@ class SpotinstClient:
     def beanstalk_import(self, region, env_id=None, env_name=None):
         """
         Import beanstalk attributes into JSON. Either env_id or env_name is required, both cannot be null
-        
+
         # Arguments
         region (String): Beanstalk region
         env_id (String): Beanstalk env id
         env_name (String): Beanstalk env name
-        
+
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         query_params = dict(region=region, environmentId=env_id, environmentName=env_name)
 
@@ -3212,16 +3212,16 @@ class SpotinstClient:
     def beanstalk_reimport(self, group_id):
         """
         Reimport beanstalk attributes
-        
+
         # Arguments
         group_id (String): Elastigroup ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         response = self.send_put(
             url=self.__base_elastigroup_url +
-            "/" + str(group_id) + 
+            "/" + str(group_id) +
             "/beanstalk/reimport",
             entity_name="beanstalk reimport"
         )
@@ -3236,16 +3236,16 @@ class SpotinstClient:
     def import_asg(self, region, asg_name, asg, dry_run=None):
         """
         import asg attributes as JSON
-        
+
         # Arguments
         region (String): ASG region
         asg_name (String): ASG Name
         asg (ASG): ASG Object
         dry_run (Bool) (Optional): if true only return JSON and not create group
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         query_params = dict(region=region, autoScalingGroupName=asg_name, dryRun=dry_run)
 
         asg = spotinst_asg.ImportASGRequest(asg)
@@ -3256,7 +3256,7 @@ class SpotinstClient:
             excluded_group_dict, self.underscore_to_camel)
 
         body_json = json.dumps(formatted_group_dict)
-        
+
         response = self.send_post(
             body=body_json,
             url=self.__base_elastigroup_url+
@@ -3274,14 +3274,14 @@ class SpotinstClient:
     def get_activity_events(self, group_id, from_date):
         """
         get activity events
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         from_date (String): From date
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         query_params = dict(fromDate=from_date)
 
         response = self.send_get(
@@ -3301,13 +3301,13 @@ class SpotinstClient:
     def ami_backup(self, group_id):
         """
         Start an AMI backup for Elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
-        
+
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         response = self.send_post(
             url=self.__base_elastigroup_url +
             "/" + group_id + "/amiBackup",
@@ -3324,13 +3324,13 @@ class SpotinstClient:
     def create_blue_green_deployment(self, group_id, blue_green_deployment):
         """
         Start a Blue Green Deployment
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         blue_green_deployment (BGDeployment): Blue Green Deployment Object
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         blue_green_deployment = spotinst_blue_green_deployment.BlueGreenDeploymentRequest(blue_green_deployment)
 
         excluded_group_dict = self.exclude_missing(json.loads(blue_green_deployment.toJSON()))
@@ -3355,12 +3355,12 @@ class SpotinstClient:
     def get_blue_green_deployment(self, group_id):
         """
         Get Blue Green Deployment for an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         # Returns
-        (Object): Elastigroup API response 
-        """ 
+        (Object): Elastigroup API response
+        """
         response = self.send_get(
             url= self.__base_elastigroup_url + "/" + group_id + "/codeDeploy/blueGreenDeployment",
             entity_name="get b/g deployment")
@@ -3375,12 +3375,12 @@ class SpotinstClient:
     def stop_blue_green_deployment(self, group_id, deployment_id):
         """
         Stop Blue Green Deployment for an elastigroup
-        
+
         # Arguments
         group_id (String): Elastigroup ID
         deployment_id (String):  BG Deployment ID
         # Returns
-        (Object): Elastigroup API response 
+        (Object): Elastigroup API response
         """
         response = self.send_put(
             url=self.__base_elastigroup_url + "/" + group_id + "/codeDeploy/blueGreenDeployment/" + deployment_id + "/stop",
@@ -3403,11 +3403,11 @@ class SpotinstClient:
     def create_application(self, app):
         """
         Create Spotinst Functions Application
-        
+
         # Arguments
         app (ApplicationCreate): ApplicationCreate Object
         # Returns
-        (Object): Functions API response 
+        (Object): Functions API response
         """
         app = spotinst_functions.ApplicationCreationRequest(app)
 
@@ -3436,11 +3436,11 @@ class SpotinstClient:
     def create_environment(self, env):
         """
         Create Spotinst Functions Environment
-        
+
         # Arguments
         env (EnvironmentCreate): EnvironmentCreate Object
         # Returns
-        (Object): Functions API response 
+        (Object): Functions API response
         """
         env = spotinst_functions.EnvironmentCreationRequest(env)
 
@@ -3469,11 +3469,11 @@ class SpotinstClient:
     def create_function(self, fx):
         """
         Create Spotinst Functions
-        
+
         # Arguments
         fx (FunctionCreate): FunctionCreate Object
         # Returns
-        (Object): Functions API response 
+        (Object): Functions API response
         """
         fx = spotinst_functions.FunctionCreationRequest(fx, self.should_print_output)
 
@@ -3588,7 +3588,7 @@ class SpotinstClient:
             query_params = self.build_query_params_with_input(query_params)
         else:
             query_params = self.build_query_params()
-        
+
         headers = dict(
             {
                 'User-Agent': agent,
@@ -3821,7 +3821,7 @@ class SpotinstClient:
                     DEFAULT_CREDENTIALS_FILE)
 
             with open(credentials_file, 'r') as credentials_file:
-                config = yaml.load(credentials_file)
+                config = yaml.load(credentials_file, Loader=yaml.SafeLoader)
 
                 if config:
                     self.account_id = config.get(


### PR DESCRIPTION
Latest pyyaml requires `Loader=` parameter when calling `yaml.load()`.

cf.: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

And remove some unneeded whitespaces.

Below warning could be resolved by this PR:
```
<path>/<to>/python3.7/site-packages/spotinst_sdk/__init__.py:3824: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  config = yaml.load(credentials_file)
```

